### PR TITLE
Refactor import use case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,13 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "io.reactivex.rxjava2:rxkotlin:$rxkotlin_version"
+
+    //Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile "org.mockito:mockito-core:2.+"
+    testCompile 'org.powermock:powermock-module-junit4:2.+'
+    testCompile 'org.powermock:powermock-module-junit4-rule:2.+'
+    testCompile 'org.powermock:powermock-api-mockito2:2.+'
 }
 
 compileKotlin {

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/ImportAudioPlugins.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/ImportAudioPlugins.kt
@@ -1,13 +1,21 @@
 package org.wycliffeassociates.otter.common.domain
 
 import io.reactivex.Completable
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import java.io.File
 
-class ImportAudioPlugins(private val pluginRegistrar: IAudioPluginRegistrar) {
-    fun import(pluginFile: File): Completable {
-        return pluginRegistrar.import(pluginFile)
+class ImportAudioPlugins(
+        private val pluginRegistrar: IAudioPluginRegistrar,
+        private val directoryProvider: IDirectoryProvider
+) {
+    fun importAll(): Completable {
+        // Imports all the plugins from the app's plugin directory
+        return pluginRegistrar.importAll(directoryProvider.audioPluginDirectory)
     }
-    fun importAll(pluginDir: File): Completable {
-        return pluginRegistrar.importAll(pluginDir)
+    fun importExternal(externalPluginFile: File): Completable {
+        // Import the external file and copy it into the app's plugin directory
+        val newFile = directoryProvider.audioPluginDirectory.resolve(externalPluginFile.name)
+        externalPluginFile.copyTo(newFile, true)
+        return pluginRegistrar.import(newFile)
     }
 }

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/domain/ImportAudioPluginsTest.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/domain/ImportAudioPluginsTest.kt
@@ -1,0 +1,74 @@
+package org.wycliffeassociates.otter.common.domain
+
+import io.reactivex.Completable
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import java.io.File
+
+class ImportAudioPluginsTest {
+    val mockPluginRegistrar = Mockito.mock(IAudioPluginRegistrar::class.java)
+    val mockDirectoryProvider = Mockito.mock(IDirectoryProvider::class.java)
+
+    // Required in Kotlin to use Mockito any() argument matcher
+    fun <T> helperAny(): T {
+        return ArgumentMatchers.any()
+    }
+
+    @Before
+    fun setup() {
+        // Configure the mock plugin registrar
+        Mockito
+                .`when`(mockPluginRegistrar.import(helperAny()))
+                .thenReturn(Completable.complete())
+        Mockito
+                .`when`(mockPluginRegistrar.importAll(helperAny()))
+                .thenReturn(Completable.complete())
+
+        // Configure the mock directory provider
+        Mockito.`when`(mockDirectoryProvider.audioPluginDirectory)
+                .thenReturn(
+                        File(
+                                ImportAudioPluginsTest::class.java
+                                        .classLoader
+                                        .getResource("plugins")
+                                        .toURI()
+                                        .path
+                        )
+                )
+    }
+
+    @Test
+    fun testImportAll() {
+        // Expect completable to finish
+        ImportAudioPlugins(mockPluginRegistrar, mockDirectoryProvider)
+                .importAll()
+                .blockingAwait()
+    }
+
+    @Test
+    fun testImportExternal() {
+        // Input file
+        val inputFile = File(ImportAudioPluginsTest::class.java
+                .classLoader
+                .getResource("audacity.yaml")
+                .toURI()
+                .path
+        )
+        // Expected output file location
+        val expectedOutputFile = mockDirectoryProvider.audioPluginDirectory.resolve("audacity.yaml")
+
+        // Expect completable to finish and file to be copied to new directory
+        ImportAudioPlugins(mockPluginRegistrar, mockDirectoryProvider)
+                .importExternal(inputFile)
+                .blockingAwait()
+
+        Assert.assertTrue(expectedOutputFile.exists())
+
+        // Tear down
+        expectedOutputFile.delete()
+    }
+}

--- a/src/test/resources/audacity.yaml
+++ b/src/test/resources/audacity.yaml
@@ -1,0 +1,8 @@
+---
+  name: Audacity
+  version: 0.0.1
+  canEdit: true
+  canRecord: true
+  executable:
+    macos: /Applications/Audacity.app/Contents/MacOS/Audacity
+  args: []


### PR DESCRIPTION
- Changed import use case to import all and import an external file. Before, it just duplicated the registrar API.
- Added import use case tests