### PR TITLE
Added rcFk param to support modified Resource table

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IResourceRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IResourceRepository.kt
@@ -11,8 +11,8 @@ interface IResourceRepository : IRepository<Content> {
     // Get resources for a collection
     fun getByCollection(collection: Collection): Single<List<Content>>
     // Link/Unlink
-    fun linkToContent(resource: Content, content: Content): Completable
+    fun linkToContent(resource: Content, content: Content, rcFk: Int): Completable
     fun unlinkFromContent(resource: Content, content: Content): Completable
-    fun linkToCollection(resource: Content, collection: Collection): Completable
+    fun linkToCollection(resource: Content, collection: Collection, rcFk: Int): Completable
     fun unlinkFromCollection(resource: Content, collection: Collection): Completable
 }


### PR DESCRIPTION
This change is to support PR #[399](https://github.com/WycliffeAssociates/otter-jvm/pull/399) which adds fields to the Content and Resource tables. This one is needed before 399 can be merged. Please also see the discussion about [399](https://github.com/WycliffeAssociates/otter-jvm/pull/399) to see why this change was necessary.