### PR TITLE
Sketch: Unify Book, Chapter, and Chunk types

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Book.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Book.kt
@@ -3,8 +3,10 @@ package org.wycliffeassociates.otter.common.data.rxmodel
 import io.reactivex.Observable
 
 data class Book(
-    val sort: Int,
-    val title: String,
-    val chapters: Observable<Chapter>,
-    val hasResources: Boolean
-)
+    override val sort: Int,
+    override val title: String,
+    override val hasResources: Boolean,
+    override val resources: Observable<Resource>,
+
+    val chapters: Observable<Chapter>
+) : BookElement

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/BookElement.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/BookElement.kt
@@ -5,7 +5,10 @@ import io.reactivex.Observable
 interface BookElement {
     val sort: Int
     val title: String
-    val audio: AssociatedAudio
     val hasResources: Boolean
     val resources: Observable<Resource>
+}
+
+interface BookElementWithAudio : BookElement {
+    val audio: AssociatedAudio
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Chapter.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Chapter.kt
@@ -5,9 +5,9 @@ import io.reactivex.Observable
 data class Chapter(
     override val sort: Int,
     override val title: String,
-    override val audio: AssociatedAudio,
     override val hasResources: Boolean,
     override val resources: Observable<Resource>,
+    override val audio: AssociatedAudio,
 
     val chunks: Observable<Chunk>
-) : BookElement
+) : BookElementWithAudio

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Chunk.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/rxmodel/Chunk.kt
@@ -5,9 +5,9 @@ import io.reactivex.Observable
 data class Chunk(
     override val sort: Int,
     override val title: String,
-    override val audio: AssociatedAudio,
     override val hasResources: Boolean,
     override val resources: Observable<Resource>,
+    override val audio: AssociatedAudio,
 
     val text: TextItem?
-) : BookElement
+) : BookElementWithAudio


### PR DESCRIPTION
Just an idea on how to unify types:

- Pull audio field from BookElement down into the new BookElementWithAudio.
- Make Book a subtype of BookElement.
- Make Chapter and Chunk subtypes of BookElementWithAudio

This PR is just to demo a possible tweak to https://github.com/WycliffeAssociates/otter-common/pull/93. See https://github.com/WycliffeAssociates/otter-common/pull/93#discussion_r271896328.