### PR TITLE
Move WorkbookRepository to common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     //Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.mockito:mockito-core:2.+"
+    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
 
     //resource container
     implementation 'org.wycliffeassociates:kotlin-resource-container'

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
@@ -1,0 +1,299 @@
+package org.wycliffeassociates.otter.common.persistence.repositories
+
+import com.jakewharton.rxrelay2.BehaviorRelay
+import com.jakewharton.rxrelay2.ReplayRelay
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.plusAssign
+import org.wycliffeassociates.otter.common.data.model.*
+import org.wycliffeassociates.otter.common.data.model.Collection
+import org.wycliffeassociates.otter.common.data.model.Take
+import org.wycliffeassociates.otter.common.data.workbook.*
+import java.util.*
+import java.util.Collections.synchronizedMap
+
+private typealias ModelTake = org.wycliffeassociates.otter.common.data.model.Take
+private typealias WorkbookTake = org.wycliffeassociates.otter.common.data.workbook.Take
+
+class WorkbookRepository(private val db: IDatabaseAccessors) : IWorkbookRepository {
+    constructor(
+        collectionRepository: ICollectionRepository,
+        contentRepository: IContentRepository,
+        resourceRepository: IResourceRepository,
+        takeRepository: ITakeRepository
+    ) : this(
+        DefaultDatabaseAccessors(
+            collectionRepository,
+            contentRepository,
+            resourceRepository,
+            takeRepository
+        )
+    )
+
+    /** Disposers for Relays in the current workbook. */
+    private val connections = CompositeDisposable()
+
+    override fun get(source: Collection, target: Collection): Workbook {
+        // Clear database connections and dispose observables for the
+        // previous Workbook if a new one was requested.
+        connections.clear()
+        return Workbook(book(source), book(target))
+    }
+
+    private fun book(bookCollection: Collection): Book {
+        return Book(
+            title = bookCollection.titleKey,
+            sort = bookCollection.sort,
+            chapters = constructBookChapters(bookCollection),
+            subtreeResources = db.getSubtreeResourceInfo(bookCollection)
+        )
+    }
+
+    private fun constructBookChapters(bookCollection: Collection): Observable<Chapter> {
+        return Observable.defer {
+            db.getChildren(bookCollection)
+                .flattenAsObservable { it }
+                .concatMapEager { constructChapter(it).toObservable() }
+        }.cache()
+    }
+
+    private fun constructChapter(chapterCollection: Collection): Single<Chapter> {
+        return db.getCollectionMetaContent(chapterCollection)
+            .map { metaContent ->
+                Chapter(
+                    title = chapterCollection.titleKey,
+                    sort = chapterCollection.sort,
+                    resources = constructResourceGroups(chapterCollection),
+                    audio = constructAssociatedAudio(metaContent),
+                    chunks = constructChunks(chapterCollection),
+                    subtreeResources = db.getSubtreeResourceInfo(chapterCollection)
+                )
+            }
+    }
+
+    private fun constructChunks(chapterCollection: Collection): Observable<Chunk> {
+        return Observable.defer {
+            db.getContentByCollection(chapterCollection)
+                .flattenAsObservable { it }
+                .filter { it.labelKey == "verse" }
+                .map(this::chunk)
+        }.cache()
+    }
+
+    private fun chunk(content: Content) = Chunk(
+        title = content.start.toString(),
+        sort = content.sort,
+        audio = constructAssociatedAudio(content),
+        resources = constructResourceGroups(content),
+        text = textItem(content)
+    )
+
+    private fun textItem(content: Content?): TextItem? {
+        return content
+            ?.format
+            ?.let { MimeType.of(it) }
+            ?.let { mimeType ->
+                content.text?.let {
+                    TextItem(it, mimeType)
+                }
+            }
+    }
+
+    private fun constructResource(title: Content, body: Content?): Resource? {
+        val titleTextItem = textItem(title)
+            ?: return null
+
+        return Resource(
+            sort = title.sort,
+            title = titleTextItem,
+            body = textItem(body),
+            titleAudio = constructAssociatedAudio(title),
+            bodyAudio = body?.let { constructAssociatedAudio(body) }
+        )
+    }
+
+    private fun constructResourceGroups(content: Content) = constructResourceGroups(
+        resourceInfoList = db.getResourceInfo(content),
+        getResourceContents = { db.getResources(content, it) }
+    )
+
+    private fun constructResourceGroups(collection: Collection) = constructResourceGroups(
+        resourceInfoList = db.getResourceInfo(collection),
+        getResourceContents = { db.getResources(collection, it) }
+    )
+
+    private fun constructResourceGroups(
+        resourceInfoList: List<ResourceInfo>,
+        getResourceContents: (ResourceInfo) -> Observable<Content>
+    ): List<ResourceGroup> {
+        return resourceInfoList.map {
+            val resources = Observable.defer {
+                getResourceContents(it)
+                    .contentsToResources()
+            }.cache()
+
+            ResourceGroup(it, resources)
+        }
+    }
+
+    private fun Observable<Content>.contentsToResources(): Observable<Resource> {
+        return this
+            .buffer(2, 1) // create a rolling window of size 2
+            .concatMapIterable { list ->
+                val a = list.getOrNull(0)
+                val b = list.getOrNull(1)
+                listOfNotNull(
+                    when {
+                        // If the first element isn't a title, skip this pair, because the body
+                        // was already used by the previous window.
+                        a?.labelKey != "title" -> null
+                        // If the second element isn't a body, just use the title. (The second
+                        // element will appear again in the next window.)
+                        b?.labelKey != "body" -> constructResource(a, null)
+                        // Else, we have a title/body pair, so use it.
+                        else -> constructResource(a, b)
+                    }
+                )
+            }
+    }
+
+    /** Build a relay primed with the current deletion state, that responds to updates by writing to the DB. */
+    private fun deletionRelay(modelTake: ModelTake): BehaviorRelay<DateHolder> {
+        val relay = BehaviorRelay.createDefault(DateHolder(modelTake.deleted))
+
+        val subscription = relay
+            .skip(1) // ignore the initial value
+            .subscribe {
+                db.updateTake(modelTake, it)
+            }
+
+        connections += subscription
+        return relay
+    }
+
+
+    private fun deselectUponDelete(take: WorkbookTake, selectedTakeRelay: BehaviorRelay<TakeHolder>) {
+        val subscription = take.deletedTimestamp
+            .filter { localDate -> localDate.value != null }
+            .filter { take == selectedTakeRelay.value?.value }
+            .map { TakeHolder(null) }
+            .subscribe(selectedTakeRelay)
+        connections += subscription
+    }
+
+    private fun workbookTake(modelTake: ModelTake): WorkbookTake {
+        return WorkbookTake(
+            name = modelTake.filename,
+            file = modelTake.path,
+            number = modelTake.number,
+            format = MimeType.WAV, // TODO
+            createdTimestamp = modelTake.created,
+            deletedTimestamp = deletionRelay(modelTake)
+        )
+    }
+
+    private fun modelTake(workbookTake: WorkbookTake, markers: List<Marker> = listOf()): ModelTake {
+        return ModelTake(
+            filename = workbookTake.file.name,
+            path = workbookTake.file,
+            number = workbookTake.number,
+            created = workbookTake.createdTimestamp,
+            deleted = null,
+            played = false,
+            markers = markers
+        )
+    }
+
+    private fun constructAssociatedAudio(content: Content): AssociatedAudio {
+        /** Map to recover model.Take objects from workbook.Take objects. */
+        val takeMap = synchronizedMap(WeakHashMap<WorkbookTake, ModelTake>())
+
+        /** The initial selected take, from the DB. */
+        val initialSelectedTake = TakeHolder(content.selectedTake?.let { workbookTake(it) })
+
+        /** Relay to send selected-take updates out to consumers, but also receive updates from UI. */
+        val selectedTakeRelay = BehaviorRelay.createDefault(initialSelectedTake)
+
+        // When we receive an update, write it to the DB.
+        val selectedTakeRelaySubscription = selectedTakeRelay
+            .distinctUntilChanged() // Don't write unless changed
+            .skip(1) // Don't write the value we just loaded from the DB
+            .subscribe {
+                content.selectedTake = it.value?.let { wbTake -> takeMap[wbTake] }
+                db.updateContent(content)
+            }
+
+        /** Initial Takes read from the DB. */
+        val takesFromDb = db.getTakeByContent(content)
+            .flattenAsObservable { list -> list.sortedBy { it.number } }
+            .map { workbookTake(it) to it }
+
+        /** Relay to send Takes out to consumers, but also receive new Takes from UI. */
+        val takesRelay = ReplayRelay.create<WorkbookTake>()
+        takesFromDb
+            // Record the mapping between data types.
+            .doOnNext { (wbTake, modelTake) -> takeMap[wbTake] = modelTake }
+            // Feed the initial list to takesRelay
+            .map { (wbTake, _) -> wbTake }
+            .subscribe(takesRelay)
+
+        val takesRelaySubscription = takesRelay
+            // When the selected take becomes deleted, deselect it.
+            .doOnNext { deselectUponDelete(it, selectedTakeRelay) }
+
+            // Keep the takeMap current.
+            .filter { !takeMap.contains(it) } // don't duplicate takes
+            .map { it to modelTake(it) }
+            .doOnNext { (wbTake, modelTake) -> takeMap[wbTake] = modelTake }
+
+            // Insert the new take into the DB.
+            .subscribe { (_, modelTake) ->
+                db.insertTakeForContent(modelTake, content)
+                    .subscribe { insertionId -> modelTake.id = insertionId }
+            }
+
+        connections += takesRelaySubscription
+        connections += selectedTakeRelaySubscription
+        return AssociatedAudio(takesRelay, selectedTakeRelay)
+    }
+
+    interface IDatabaseAccessors {
+        fun getChildren(collection: Collection): Single<List<Collection>>
+        fun getCollectionMetaContent(collection: Collection): Single<Content>
+        fun getContentByCollection(collection: Collection): Single<List<Content>>
+        fun updateContent(content: Content): Completable
+        fun getResources(content: Content, info: ResourceInfo): Observable<Content>
+        fun getResources(collection: Collection, info: ResourceInfo): Observable<Content>
+        fun getResourceInfo(content: Content): List<ResourceInfo>
+        fun getResourceInfo(collection: Collection): List<ResourceInfo>
+        fun getSubtreeResourceInfo(collection: Collection): List<ResourceInfo>
+        fun insertTakeForContent(take: ModelTake, content: Content): Single<Int>
+        fun getTakeByContent(content: Content): Single<List<Take>>
+        fun updateTake(take: ModelTake, date: DateHolder): Completable
+    }
+}
+
+private class DefaultDatabaseAccessors(
+    private val collectionRepo: ICollectionRepository,
+    private val contentRepo: IContentRepository,
+    private val resourceRepo: IResourceRepository,
+    private val takeRepo: ITakeRepository
+) : WorkbookRepository.IDatabaseAccessors {
+    override fun getChildren(collection: Collection) = collectionRepo.getChildren(collection)
+
+    override fun getCollectionMetaContent(collection: Collection) = contentRepo.getCollectionMetaContent(collection)
+    override fun getContentByCollection(collection: Collection) = contentRepo.getByCollection(collection)
+    override fun updateContent(content: Content) = contentRepo.update(content)
+
+    override fun getResources(content: Content, info: ResourceInfo) = resourceRepo.getResources(content, info)
+    override fun getResources(collection: Collection, info: ResourceInfo) = resourceRepo.getResources(collection, info)
+    override fun getResourceInfo(content: Content) = resourceRepo.getResourceInfo(content)
+    override fun getResourceInfo(collection: Collection) = resourceRepo.getResourceInfo(collection)
+    override fun getSubtreeResourceInfo(collection: Collection) = resourceRepo.getSubtreeResourceInfo(collection)
+
+    override fun insertTakeForContent(take: ModelTake, content: Content) = takeRepo.insertForContent(take, content)
+    override fun getTakeByContent(content: Content) = takeRepo.getByContent(content)
+    override fun updateTake(take: ModelTake, date: DateHolder) = takeRepo.update(take.copy(deleted = date.value))
+}

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/TestWorkbookRepository.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/TestWorkbookRepository.kt
@@ -1,0 +1,508 @@
+package org.wycliffeassociates.otter.common.persistence.repositories
+
+import com.nhaarman.mockitokotlin2.*
+import io.reactivex.Observable
+import io.reactivex.Single
+import org.junit.Assert
+import org.junit.Test
+import org.wycliffeassociates.otter.common.data.model.*
+import org.wycliffeassociates.otter.common.data.model.Collection
+import org.wycliffeassociates.otter.common.data.workbook.*
+import org.wycliffeassociates.otter.common.data.workbook.Take
+import org.wycliffeassociates.otter.common.persistence.repositories.WorkbookRepository.IDatabaseAccessors
+import java.io.File
+import java.time.LocalDate
+
+class TestWorkbookRepository {
+    /** When a unique ID is needed, just use this. */
+    @Suppress("VAL_REASSIGNMENT_VIA_BACKING_FIELD")
+    private val autoincrement: Int = 1
+        get() = field++
+
+    private val english = Language("en", "English", "English", "ltr", isGateway = true, id = autoincrement)
+    private val latin = Language("la", "Latin", "Latin", "ltr", isGateway = false, id = autoincrement)
+
+    private val rcBase = ResourceMetadata(
+        conformsTo = "rc0.2",
+        creator = "Door43 World Missions Community",
+        description = "Description",
+        format = "text/usfm",
+        identifier = "ulb",
+        issued = LocalDate.now(),
+        language = english,
+        modified = LocalDate.now(),
+        publisher = "unfoldingWord",
+        subject = "Bible",
+        type = "bundle",
+        title = "Unlocked Literal Bible",
+        version = "1",
+        path = File(".")
+    )
+    private val rcSource = rcBase.copy(id = autoincrement, language = english)
+    private val rcTarget = rcBase.copy(id = autoincrement, language = latin)
+
+    private val resourceInfoTn = ResourceInfo(
+        slug = "tn",
+        title = "translationNotes"
+    )
+
+    private val collectionBase = Collection(
+        sort = 1,
+        slug = "gen",
+        labelKey = "project",
+        titleKey = "Genesis",
+        resourceContainer = null
+    )
+    private val collSource = collectionBase.copy(resourceContainer = rcSource, id = autoincrement)
+    private val collTarget = collectionBase.copy(resourceContainer = rcTarget, id = autoincrement)
+
+    private fun buildWorkbook(
+        db: IDatabaseAccessors,
+        source: Collection = collSource,
+        target: Collection = collTarget
+    ) = WorkbookRepository(db).get(source, target)
+
+    private fun resourceSlugArray(resourceInfos: List<ResourceInfo>) =
+        resourceInfos
+            .map(ResourceInfo::slug)
+            .sorted()
+            .toTypedArray()
+
+    private fun resourceSlugArray(resourceGroups: Iterable<ResourceGroup>) =
+        resourceSlugArray(resourceGroups.map { it.info })
+
+    private fun buildBasicTestDb(): IDatabaseAccessors = mock()
+
+    private object BasicTestParams {
+        const val chaptersPerBook = 3
+        const val chunksPerChapter = 5
+    }
+
+    private fun buildBasicTestWorkbook(mockedDb: IDatabaseAccessors = buildBasicTestDb()): Workbook {
+        whenever(
+            mockedDb.getChildren(any())
+        ).thenAnswer { invocation ->
+            val collection = invocation.getArgument<Collection>(0)!!
+            Single.just(
+                when (collection.slug.count { it == '_' }) {
+                    0 -> {
+                        (1..BasicTestParams.chaptersPerBook).map { chapter ->
+                            Collection(
+                                sort = chapter,
+                                slug = collection.slug + "_" + chapter,
+                                id = autoincrement,
+                                resourceContainer = collection.resourceContainer,
+                                titleKey = chapter.toString(),
+                                labelKey = "chapter"
+                            )
+                        }
+                    }
+                    else -> emptyList()
+                }
+            )
+        }
+
+        whenever(
+            mockedDb.getContentByCollection(any())
+        ).thenAnswer { invocation ->
+            val collection = invocation.getArgument<Collection>(0)!!
+            val format = if (collection.resourceContainer == rcTarget) "audio/wav" else "text/usfm"
+            Single.just(
+                when (collection.slug.count { it == '_' }) {
+                    1 -> {
+                        (1..BasicTestParams.chunksPerChapter).map { verse ->
+                            Content(
+                                id = autoincrement,
+                                start = verse,
+                                end = verse,
+                                sort = verse,
+                                labelKey = "verse",
+                                type = ContentType.TEXT,
+                                format = format,
+                                text = "/v $verse but test everything; hold fast what is good.",
+                                selectedTake = null
+                            )
+                        }
+                    }
+                    else -> emptyList()
+                }
+            )
+        }
+
+        whenever(
+            mockedDb.getCollectionMetaContent(any())
+        ).thenReturn(
+            Single.just(
+                Content(
+                    sort = 0,
+                    labelKey = "chapter",
+                    start = 1,
+                    end = BasicTestParams.chunksPerChapter,
+                    selectedTake = null,
+                    text = null,
+                    format = "WAV",
+                    type = ContentType.META,
+                    id = autoincrement
+                )
+            )
+        )
+
+        whenever(
+            mockedDb.getSubtreeResourceInfo(any())
+        ).thenAnswer { invocation ->
+            val collection = invocation.getArgument<Collection>(0)!!
+            when (rcSource.id) {
+                collection.resourceContainer?.id -> listOf(resourceInfoTn)
+                else -> emptyList()
+            }
+        }
+
+        whenever(
+            mockedDb.getResourceInfo(any<Collection>())
+        ).thenReturn(
+            listOf(resourceInfoTn)
+        )
+
+        whenever(
+            mockedDb.getResourceInfo(any<Content>())
+        ).thenReturn(
+            listOf(resourceInfoTn)
+        )
+
+        whenever(
+            mockedDb.getResources(any<Content>(), any())
+        ).thenAnswer { invocation ->
+            val content = invocation.getArgument<Content>(0)!!
+            val info = invocation.getArgument<ResourceInfo>(1)!!
+            if (content.start == 2 && info == resourceInfoTn) {
+                Observable.fromArray(
+                    Content(
+                        id = autoincrement,
+                        start = content.start,
+                        end = content.end,
+                        sort = 1,
+                        labelKey = "title",
+                        type = ContentType.TITLE,
+                        format = "text/markdown",
+                        text = "but test everything; hold fast what is good.",
+                        selectedTake = null
+                    ),
+                    Content(
+                        id = autoincrement,
+                        start = content.start,
+                        end = content.end,
+                        sort = 2,
+                        labelKey = "body",
+                        type = ContentType.BODY,
+                        format = "text/markdown",
+                        text = "The original author may not have had TDD in mind.",
+                        selectedTake = null
+                    )
+                )
+            } else {
+                Observable.empty()
+            }
+        }
+
+        whenever(
+            mockedDb.getResources(any<Collection>(), any())
+        ).thenAnswer { invocation ->
+            val collection = invocation.getArgument<Collection>(0)!!
+            val info = invocation.getArgument<ResourceInfo>(1)!!
+            if (collection.titleKey == "2" && info == resourceInfoTn) {
+                Observable.fromArray(
+                    Content(
+                        id = autoincrement,
+                        start = 1,
+                        end = BasicTestParams.chunksPerChapter,
+                        sort = 1,
+                        labelKey = "title",
+                        type = ContentType.TITLE,
+                        format = "text/markdown",
+                        text = "Chapter 2 notes",
+                        selectedTake = null
+                    ),
+                    Content(
+                        id = autoincrement,
+                        start = 1,
+                        end = BasicTestParams.chunksPerChapter,
+                        sort = 2,
+                        labelKey = "body",
+                        type = ContentType.BODY,
+                        format = "text/markdown",
+                        text = "Chapter 2 is a fine chapter. Here are the notes.",
+                        selectedTake = null
+                    )
+                )
+            } else {
+                Observable.empty()
+            }
+        }
+
+        whenever(
+            mockedDb.getTakeByContent(any())
+        ).thenAnswer { invocation ->
+            val content = invocation.getArgument<Content>(0)!!
+            val take = if (content.format == "audio/wav" && content.start == 3) {
+                val id = autoincrement
+                org.wycliffeassociates.otter.common.data.model.Take(
+                    number = id,
+                    id = id,
+                    path = File("."),
+                    filename = ".",
+                    markers = listOf(),
+                    played = false,
+                    created = LocalDate.now(),
+                    deleted = null
+                )
+            } else {
+                null
+            }
+            Single.just(listOfNotNull(take))
+        }
+
+        whenever(
+            mockedDb.insertTakeForContent(any(), any())
+        ).thenReturn(
+            Single.just(autoincrement)
+        )
+
+        return buildWorkbook(mockedDb)
+    }
+
+    @Test
+    fun workbookHasBooks() {
+        val workbook = buildBasicTestWorkbook()
+
+        Assert.assertEquals(1, workbook.source.sort)
+        Assert.assertEquals(1, workbook.target.sort)
+        Assert.assertEquals("Genesis", workbook.source.title)
+        Assert.assertEquals("Genesis", workbook.target.title)
+        Assert.assertArrayEquals(arrayOf("tn"), resourceSlugArray(workbook.source.subtreeResources))
+        Assert.assertArrayEquals(arrayOf(), resourceSlugArray(workbook.target.subtreeResources))
+    }
+
+    @Test
+    fun chaptersAreLazyLoad() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+
+        // Load some things that shouldn't trigger chapter fetch, and verify no DB call is made
+        Assert.assertEquals("Genesis", workbook.source.title)
+        Assert.assertArrayEquals(arrayOf("tn"), resourceSlugArray(workbook.source.subtreeResources))
+        verify(mockedDb, times(0)).getChildren(any())
+
+        // Fetch chapters, and verify one DB call is made
+        workbook.source.chapters.blockingLast()
+        verify(mockedDb, times(1)).getChildren(any())
+    }
+
+    @Test
+    fun chaptersAreCached() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+
+        // Fetch chapters twice, and verify only one DB call is made
+        workbook.source.chapters.blockingLast()
+        workbook.source.children.blockingLast()
+        verify(mockedDb, times(1)).getChildren(any())
+    }
+
+    @Test
+    fun chaptersIsAliasOfBookChildren() {
+        val workbook = buildBasicTestWorkbook()
+
+        Assert.assertArrayEquals(
+            workbook.source.chapters.blockingIterable().toList().toTypedArray(),
+            workbook.source.children.blockingIterable().toList().toTypedArray()
+        )
+    }
+
+    @Test
+    fun chunksAreLazyLoad() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+
+        // Load some things that shouldn't trigger chunk fetch, and verify no DB call is made
+        Assert.assertEquals(1, chapter.sort)
+        Assert.assertArrayEquals(arrayOf("tn"), resourceSlugArray(chapter.resources))
+        verify(mockedDb, times(0)).getContentByCollection(any())
+
+        // Fetch chunks, and verify one DB call is made
+        chapter.chunks.blockingLast()
+        verify(mockedDb, times(1)).getContentByCollection(any())
+    }
+
+    @Test
+    fun chunksAreCached() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+
+        // Fetch chunks twice, and verify only one DB call is made
+        chapter.chunks.blockingLast()
+        chapter.children.blockingLast()
+        verify(mockedDb, times(1)).getContentByCollection(any())
+    }
+
+    @Test
+    fun chunksIsAliasOfChapterChildren() {
+        val workbook = buildBasicTestWorkbook()
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+
+        Assert.assertArrayEquals(
+            chapter.children.blockingIterable().sortedBy { it.sort }.toTypedArray(),
+            chapter.chunks.blockingIterable().sortedBy { it.sort }.toTypedArray()
+        )
+    }
+
+    @Test
+    fun subtreeResourcesWork() {
+        val workbook = buildBasicTestWorkbook()
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+
+        Assert.assertArrayEquals(arrayOf(resourceInfoTn), chapter.subtreeResources.toTypedArray())
+    }
+
+    @Test
+    fun resourceGroupsHaveCorrectInfo() {
+        val workbook = buildBasicTestWorkbook()
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
+        val resourceGroups = chunk.resources
+
+        val expected = 1
+        Assert.assertEquals("This chunk should have $expected ResourceGroups", expected, resourceGroups.size)
+        Assert.assertEquals("ResourceInfo", resourceInfoTn, resourceGroups.first().info)
+    }
+
+    @Test
+    fun resourcesAreLazyLoad() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
+        val resourceGroup = chunk.resources.first()
+
+        // Load some things that shouldn't trigger resource fetch, and verify no DB call is made
+        Assert.assertEquals(resourceInfoTn, resourceGroup.info)
+        verify(mockedDb, times(0)).getResources(any<Content>(), any())
+
+        // Fetch chunks, and verify one DB call is made
+        resourceGroup.resources.blockingLast()
+        verify(mockedDb, times(1)).getResources(any<Content>(), any())
+    }
+
+    @Test
+    fun resourceGroupsHaveCorrectResources() {
+        val workbook = buildBasicTestWorkbook()
+        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
+        val resourceGroup = chunk.resources.firstOrNull()
+        Assert.assertNotNull(resourceGroup)
+        val resources = resourceGroup!!.resources.blockingIterable().toList()
+
+        val expected = 1
+        Assert.assertEquals("This chunk should have $expected Resources", expected, resources.size)
+        Assert.assertTrue("Expected resource text", resources.first().body?.text?.contains("TDD") ?: false)
+    }
+
+    @Test
+    fun pushingToTakesRelayCallsDbWrite() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.blockingFirst()
+        val takes = chunk.audio.takes
+
+        // Verify precondition - no DB writes yet
+        verify(mockedDb, times(0)).insertTakeForContent(any(), any())
+
+        // Push a new take, and verify the DB is called
+        val take = Take(
+            name = "TakeName",
+            file = File("."),
+            format = MimeType.WAV,
+            number = autoincrement,
+            createdTimestamp = LocalDate.now()
+        )
+        takes.accept(take)
+        verify(mockedDb, times(1)).insertTakeForContent(any(), any())
+    }
+
+    @Test
+    fun deletingTakeCallsDbWrite() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
+        val takes = chunk.audio.takes
+        val take = takes.blockingFirst()
+
+        // Verify precondition - no DB writes yet
+        verify(mockedDb, times(0)).updateTake(any(), any())
+
+        // Delete a take, and verify the DB is called
+        take.deletedTimestamp.accept(DateHolder(LocalDate.now()))
+        verify(mockedDb, times(1)).updateTake(any(), any())
+    }
+
+    @Test
+    fun settingSelectedTakeCallsDbWrite() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
+        val takes = chunk.audio.takes
+        val take = takes.blockingFirst()
+
+        // Verify precondition - no DB writes yet
+        verify(mockedDb, times(0)).updateContent(any())
+
+        // Select a take, and verify the DB is called
+        chunk.audio.selected.accept(TakeHolder(take))
+        verify(mockedDb, times(1)).updateContent(any())
+    }
+
+    @Test
+    fun deletingSelectedTakeResetsSelection() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
+        val takes = chunk.audio.takes
+        val take = takes.blockingFirst()
+
+        // Select a take to set up the test, and verify the preconditions
+        chunk.audio.selected.accept(TakeHolder(take))
+        verify(mockedDb, times(1)).updateContent(any())
+        Assert.assertNotNull("Selection should be non-null", chunk.audio.selected.value?.value)
+
+        // Delete the take, and confirm the selection is cleared
+        take.deletedTimestamp.accept(DateHolder.now())
+        verify(mockedDb, times(2)).updateContent(any())
+        Assert.assertNull("Selection should be null", chunk.audio.selected.value?.value)
+    }
+
+    @Test
+    fun textItemsHaveCorrectValues() {
+        val mockedDb = buildBasicTestDb()
+        val workbook = buildBasicTestWorkbook(mockedDb)
+        val chapter = workbook.source.chapters.blockingFirst()
+        val chunks = chapter.chunks.blockingIterable().sortedBy { it.sort }
+
+        Assert.assertArrayEquals(
+            "Expected chunk titles",
+            (1..BasicTestParams.chunksPerChapter).map(Int::toString).toTypedArray(),
+            chunks.map { it.title }.toTypedArray()
+        )
+        chunks.forEach {
+            Assert.assertTrue(
+                "Chunk text expected",
+                it.text?.text?.startsWith("/v ${it.title}")
+                    ?: false
+            )
+        }
+    }
+}


### PR DESCRIPTION
WorkbookRepository doesn't depend on desktop JVM, so let's move it to common.

Corresponds to https://github.com/WycliffeAssociates/otter-jvm/pull/452
