### PR TITLE
Fix IDEA/Gradle composite build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = '8woc2018-common'
-includeBuild "../kotlin-resource-container"
+boolean inComposite = gradle.parent != null
+if (!inComposite) {
+    includeBuild "../kotlin-resource-container"
+}


### PR DESCRIPTION
When IDEA creates a composite build, the common project shouldn't try to include kotlin-resource-container, because composites can't contain composites.