### PR TITLE
Allow importing OBS markdown files.

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/collections/tree/Tree.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/collections/tree/Tree.kt
@@ -1,8 +1,5 @@
 package org.wycliffeassociates.otter.common.collections.tree
 
-typealias Tree = OtterTree<Any>
-typealias TreeNode = OtterTreeNode<Any>
-
 class OtterTree<T>(value: T) : OtterTreeNode<T>(value) {
 
     //private mutable list, public immutable accessor

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/Collection.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/Collection.kt
@@ -1,10 +1,10 @@
 package org.wycliffeassociates.otter.common.data.model
 
 data class Collection(
-        var sort: Int,
-        var slug: String,
-        var labelKey: String,
-        var titleKey: String,
-        var resourceContainer: ResourceMetadata?,
-        var id: Int = 0
-)
+    var sort: Int,
+    var slug: String,
+    var labelKey: String,
+    var titleKey: String,
+    var resourceContainer: ResourceMetadata?,
+    var id: Int = 0
+) : CollectionOrContent

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/CollectionOrContent.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/CollectionOrContent.kt
@@ -1,0 +1,5 @@
+package org.wycliffeassociates.otter.common.data.model
+
+interface CollectionOrContent {
+
+}

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/Content.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/Content.kt
@@ -1,13 +1,13 @@
 package org.wycliffeassociates.otter.common.data.model
 
 data class Content(
-        var sort: Int,
-        var labelKey: String,
-        var start: Int,
-        var end: Int,
-        var selectedTake: Take?,
-        var text: String?,
-        var format: String?,
-        var type: ContentType,
-        var id: Int = 0
-)
+    var sort: Int,
+    var labelKey: String,
+    var start: Int,
+    var end: Int,
+    var selectedTake: Take?,
+    var text: String?,
+    var format: String?,
+    var type: ContentType,
+    var id: Int = 0
+) : CollectionOrContent

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/MimeType.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/MimeType.kt
@@ -1,8 +1,8 @@
 package org.wycliffeassociates.otter.common.data.model
 
 enum class MimeType(vararg types: String) {
-    USFM("text/usfm", "text/x-usfm"),
-    MARKDOWN("text/markdown", "text/x-markdown"),
+    USFM("text/usfm", "text/x-usfm", "usfm"),
+    MARKDOWN("text/markdown", "text/x-markdown", "markdown"),
     WAV("audio/wav", "audio/wave", "audio/x-wave", "audio/vnd.wave");
 
     val accepted = types.toList()
@@ -13,6 +13,6 @@ enum class MimeType(vararg types: String) {
             .flatMap { mt -> mt.accepted.map { it to mt } }
             .associate { it }
 
-        fun of(type: String) = map[type]
+        fun of(type: String) = map[type.toLowerCase()]
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/IProjectReader.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/IProjectReader.kt
@@ -1,6 +1,9 @@
 package org.wycliffeassociates.otter.common.domain.resourcecontainer.project
 
-import org.wycliffeassociates.otter.common.collections.tree.Tree
+import org.wycliffeassociates.otter.common.collections.tree.OtterTree
+import org.wycliffeassociates.otter.common.data.model.CollectionOrContent
+import org.wycliffeassociates.otter.common.data.model.MimeType
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportException
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.markdown.MarkdownProjectReader
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.usfm.UsfmProjectReader
@@ -8,15 +11,22 @@ import org.wycliffeassociates.resourcecontainer.ResourceContainer
 import org.wycliffeassociates.resourcecontainer.entity.Project
 
 interface IProjectReader {
-    fun constructProjectTree(container: ResourceContainer,
-                             project: Project,
-                             zipEntryTreeBuilder: IZipEntryTreeBuilder
-    ): Pair<ImportResult, Tree>
+    /** @throws ImportException */
+    fun constructProjectTree(
+        container: ResourceContainer,
+        project: Project,
+        zipEntryTreeBuilder: IZipEntryTreeBuilder
+    ): OtterTree<CollectionOrContent>
 
     companion object {
-        fun build(format: String): IProjectReader? = when (format.toLowerCase()) {
-            "text/usfm" -> UsfmProjectReader()
-            "text/markdown" -> MarkdownProjectReader()
+        fun build(format: String, isHelp: Boolean): IProjectReader? = when (MimeType.of(format)) {
+            MimeType.USFM -> {
+                if (isHelp) throw ImportException(ImportResult.INVALID_RC)
+                UsfmProjectReader()
+            }
+            MimeType.MARKDOWN -> {
+                MarkdownProjectReader(isHelp)
+            }
             else -> null
         }
     }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReader.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReader.kt
@@ -2,12 +2,9 @@ package org.wycliffeassociates.otter.common.domain.resourcecontainer.project.mar
 
 import org.wycliffeassociates.otter.common.collections.tree.OtterTree
 import org.wycliffeassociates.otter.common.collections.tree.OtterTreeNode
-import org.wycliffeassociates.otter.common.collections.tree.Tree
-import org.wycliffeassociates.otter.common.collections.tree.TreeNode
+import org.wycliffeassociates.otter.common.data.model.*
 import org.wycliffeassociates.otter.common.data.model.Collection
-import org.wycliffeassociates.otter.common.data.model.Content
-import org.wycliffeassociates.otter.common.data.model.ContentLabel
-import org.wycliffeassociates.otter.common.data.model.ContentType
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportException
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.IProjectReader
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.IZipEntryTreeBuilder
@@ -15,22 +12,25 @@ import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.Otte
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.OtterFile.Companion.otterFileF
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
 import org.wycliffeassociates.resourcecontainer.entity.Project
-import java.io.BufferedReader
 import java.io.Closeable
 import java.io.File
 import java.nio.file.Path
 import java.util.*
 import java.util.zip.ZipFile
 
-private const val FORMAT = "text/markdown"
 private val extensions = Regex(".+\\.(md|mkdn?|mdown|markdown)$", RegexOption.IGNORE_CASE)
 
-class MarkdownProjectReader() : IProjectReader {
+class MarkdownProjectReader(private val isHelp: Boolean) : IProjectReader {
+    private val collectionForEachFile = !isHelp
+
+    private data class Contents(val collection: Collection, val list: List<Content>?)
+
+    /** @throws ImportException */
     override fun constructProjectTree(
-            container: ResourceContainer,
-            project: Project,
-            zipEntryTreeBuilder: IZipEntryTreeBuilder
-    ): Pair<ImportResult, Tree> {
+        container: ResourceContainer,
+        project: Project,
+        zipEntryTreeBuilder: IZipEntryTreeBuilder
+    ): OtterTree<CollectionOrContent> {
         val toClose = mutableListOf<Closeable>()
         try {
             val projectRoot: OtterFile
@@ -58,95 +58,108 @@ class MarkdownProjectReader() : IProjectReader {
             val collectionKey = container.manifest.dublinCore.identifier
 
             return projectTreeRoot
-                    .filterMarkdownFiles()
-                    ?.map<Any> { f -> contentList(f) ?: collection(collectionKey, f, projectRoot) }
-                    ?.flattenContent()
-                    ?.let { Pair(ImportResult.SUCCESS, it) }
-                    ?: Pair(ImportResult.LOAD_RC_ERROR, Tree(Unit))
+                .filterMarkdownFiles()
+                ?.map { f ->
+                    Contents(
+                        collection(collectionKey, f, projectRoot),
+                        if (f.isFile) f.readContents() else null
+                    )
+                }
+                ?.flattenContent()
+                ?: throw ImportException(ImportResult.LOAD_RC_ERROR)
         } finally {
             toClose.forEach { it.close() }
         }
     }
 
     private fun fileToId(f: OtterFile): Int =
-            f.nameWithoutExtension.toIntOrNull() ?: 0
+        f.nameWithoutExtension.toIntOrNull() ?: 0
 
     private fun fileToSlug(f: OtterFile, root: OtterFile): String =
-            root.parentFile?.let { parentFile ->
-                f.toRelativeString(parentFile)
-                        .split('/', '\\')
-                        .map { it.toIntOrNull()?.toString() ?: it }
-                        .joinToString("_")
-            } ?: throw Exception("fileToSlug() call should not be made with null parentFile") // TODO. Also we could move this exception somewhere else if we set parentFile to a val
+        root.parentFile?.let { parentFile ->
+            f.toRelativeString(parentFile)
+                .substringBeforeLast('.')
+                .split('/', '\\')
+                .map { it.toIntOrNull()?.toString() ?: it }
+                .joinToString("_")
+        }
+            ?: throw Exception("fileToSlug() call should not be made with null parentFile") // TODO. Also we could move this exception somewhere else if we set parentFile to a val
 
-    private fun bufferedReaderProvider(f: OtterFile): (() -> BufferedReader)? =
-            if (f.isFile) {
-                { f.bufferedReader() }
-            } else null
-
-    private fun collection(key: String, f: OtterFile, projectRoot: OtterFile): Collection =
-            collection(key, fileToSlug(f, projectRoot), fileToId(f))
-
-    private fun collection(key: String, slug: String, id: Int): Collection =
-            Collection(
-                    sort = id,
-                    slug = slug,
-                    labelKey = key,
-                    titleKey = "$id",
-                    resourceContainer = null)
+    private fun collection(key: String, f: OtterFile, projectRoot: OtterFile): Collection {
+        val id = fileToId(f)
+        return Collection(
+            sort = id,
+            slug = fileToSlug(f, projectRoot),
+            labelKey = key,
+            titleKey = "$id",
+            resourceContainer = null
+        )
+    }
 
     private fun content(sort: Int, id: Int, text: String, type: ContentType): Content? =
-            if (text.isEmpty()) null
-            else Content(sort, ContentLabel.of(type).value, id, id, null, text, FORMAT, type)
+        if (text.isEmpty()) null
+        else Content(sort, ContentLabel.of(type).value, id, id, null, text, MimeType.MARKDOWN.norm, type)
 
-    private fun contentList(f: OtterFile): List<Content>? =
-            bufferedReaderProvider(f)
-                    ?.let { contentList(it, fileToId(f)) }
-
-    private fun contentList(brp: () -> BufferedReader, fileId: Int): List<Content> {
-        val helpResources = brp().use { ParseMd.parse(it) }
+    /**
+     * Read an MD file and return its contents
+     * @receiver must be a file, not a directory
+     */
+    private fun OtterFile.readContents(): List<Content> {
+        val fileId = fileToId(this)
         var sort = 1
-        return helpResources.flatMap { helpResource ->
-            listOfNotNull(
-                    content(sort++, fileId, helpResource.title, ContentType.TITLE),
-                    content(sort++, fileId, helpResource.body, ContentType.BODY)
-            )
+        return if (isHelp) {
+            this.bufferedReader()
+                .use { ParseMd.parseHelp(it) }
+                .flatMap { helpResource ->
+                    listOfNotNull(
+                        content(sort++, fileId, helpResource.title, ContentType.TITLE),
+                        content(sort++, fileId, helpResource.body, ContentType.BODY)
+                    )
+                }
+        } else {
+            this.bufferedReader()
+                .use { ParseMd.parse(it) }
+                .mapNotNull { content(sort++, fileId, it, ContentType.TEXT) }
         }
     }
+
+    private fun OtterTree<OtterFile>.filterMarkdownFiles(): OtterTree<OtterFile>? =
+        this.filterPreserveParents { it.isFile && extensions.matches(it.name) }
+
+    /** Expand any list values to be individual tree nodes. */
+    private fun OtterTree<Contents>.flattenContent(): OtterTree<CollectionOrContent> =
+        OtterTree<CollectionOrContent>(this.value.collection).also { newRoot ->
+            this.children.forEach { c ->
+                if (c.value.list != null) {
+                    // Add nodes from content list
+                    val addTo =
+                        if (collectionForEachFile)
+                            OtterTree<CollectionOrContent>(c.value.collection).also(newRoot::addChild)
+                        else
+                            newRoot
+                    addTo.addAll(c.value.list.map { OtterTreeNode(it) })
+                } else if (c is OtterTree<Contents>) {
+                    // Add node from child
+                    newRoot.addChild(c.flattenContent())
+                }
+            }
+        }
 }
 
 internal fun File.buildFileTree(): OtterTree<OtterFile> {
     var treeRoot: OtterTree<OtterFile>? = null
     val treeCursor = ArrayDeque<OtterTree<OtterFile>>()
     this.walkTopDown()
-            .onEnter { newDir ->
-                OtterTree(otterFileF(newDir)).let { newDirNode ->
-                    treeCursor.peek()?.addChild(newDirNode)
-                    treeCursor.push(newDirNode)
-                    true
-                }
+        .onEnter { newDir ->
+            OtterTree(otterFileF(newDir)).let { newDirNode ->
+                treeCursor.peek()?.addChild(newDirNode)
+                treeCursor.push(newDirNode)
+                true
             }
-            .onLeave { treeRoot = treeCursor.pop() }
-            .filter { it.isFile }
-            .map { OtterTreeNode(otterFileF(it)) }
-            .forEach { treeCursor.peek()?.addChild(it) }
+        }
+        .onLeave { treeRoot = treeCursor.pop() }
+        .filter { it.isFile }
+        .map { OtterTreeNode(otterFileF(it)) }
+        .forEach { treeCursor.peek()?.addChild(it) }
     return treeRoot ?: OtterTree(otterFileF(this))
 }
-
-private fun OtterTree<OtterFile>.filterMarkdownFiles(): OtterTree<OtterFile>? =
-        this.filterPreserveParents { it.isFile && extensions.matches(it.name) }
-
-private fun Tree.flattenContent(): Tree =
-        Tree(this.value).also {
-            it.addAll(
-                    if (this.children.all { c -> c.value is List<*> }) {
-                        this.children
-                                .flatMap { c -> c.value as List<*> }
-                                .filterNotNull()
-                                .map { TreeNode(it) }
-                    } else {
-                        this.children
-                                .map { if (it is Tree) it.flattenContent() else it }
-                    }
-            )
-        }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/ParseMd.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/ParseMd.kt
@@ -10,7 +10,7 @@ object ParseMd {
     private val isTitleRegex = Regex("^#+\\s*[^#\\s]+")
     private val titleTextRegex = Regex("^#+\\s*")
 
-    fun parse(reader: BufferedReader): List<HelpResource> {
+    fun parseHelp(reader: BufferedReader): List<HelpResource> {
         val helpResourceList = ArrayList<HelpResource>()
 
         reader.forEachLine {
@@ -32,6 +32,9 @@ object ParseMd {
         }
         return helpResourceList
     }
+
+    fun parse(reader: BufferedReader): List<String> =
+        reader.lineSequence().filter { it.isNotBlank() }.toList()
 
     internal fun getTitleText(line: String): String? {
         titleTextRegex.find(line)?.let {

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IResourceContainerRepository.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IResourceContainerRepository.kt
@@ -1,10 +1,15 @@
 package org.wycliffeassociates.otter.common.persistence.repositories
 
 import io.reactivex.Single
-import org.wycliffeassociates.otter.common.collections.tree.Tree
+import org.wycliffeassociates.otter.common.collections.tree.OtterTree
+import org.wycliffeassociates.otter.common.data.model.CollectionOrContent
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
 
 interface IResourceContainerRepository {
-    fun importResourceContainer(rc: ResourceContainer, rcTree: Tree, languageSlug: String): Single<ImportResult>
+    fun importResourceContainer(
+        rc: ResourceContainer,
+        rcTree: OtterTree<CollectionOrContent>,
+        languageSlug: String
+    ): Single<ImportResult>
 }

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReaderTest.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReaderTest.kt
@@ -27,13 +27,13 @@ class MarkdownProjectReaderTest {
 
     @Test
     fun testBuilderMarkdown() {
-        val reader = IProjectReader.build("text/markdown")
+        val reader = IProjectReader.build("text/markdown", false)
         TestCase.assertTrue(reader is MarkdownProjectReader)
     }
 
     @Test
     fun testBuilderUnknown() {
-        val reader = IProjectReader.build("unknown")
+        val reader = IProjectReader.build("unknown", false)
         TestCase.assertTrue(reader == null)
     }
 

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/ParseMdTest.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/ParseMdTest.kt
@@ -11,7 +11,7 @@ typealias TestCaseForParser = Pair<List<String>, List<HelpResource>>
 
 class ParseMdTest {
     // These test cases are designed to test the creation of the HelpResource data objects
-    // (including the branching logic of the parse() function)
+    // (including the branching logic of the parseHelp() function)
     private val testParseCases: List<TestCaseForParser> = listOf(
             listOf(
                     "# Title 1",
@@ -113,7 +113,7 @@ class ParseMdTest {
     fun testParse() {
         testParseCases.forEach {
             val bufferedReader = getBufferedReader(it.first)
-            val helpResourceList = ParseMd.parse(bufferedReader)
+            val helpResourceList = ParseMd.parseHelp(bufferedReader)
             try {
                 assertEquals(it.second, helpResourceList)
             } catch (e: AssertionError) {


### PR DESCRIPTION
- Use ContentType.TEXT for non-help markdown files.
- For non-help markdown RCs, use a different content hierarchy.
- MimeType enum instead of string literals; be more forgiving on format strings.
- Allow collections and content at the same tree level.
- Refactor MarkdownProjectReader.
- Create union type CollectionOrContent.
- More type safety in project readers.

For https://github.com/WycliffeAssociates/otter-jvm/issues/460
Also see https://github.com/WycliffeAssociates/otter-jvm/pull/461