### PR TITLE
Mark OBS project collections

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReader.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/markdown/MarkdownProjectReader.kt
@@ -20,10 +20,21 @@ import java.util.zip.ZipFile
 
 private val extensions = Regex(".+\\.(md|mkdn?|mdown|markdown)$", RegexOption.IGNORE_CASE)
 
+private const val PRIMARY_COLLECTION_KEY = "project"
+private const val SECONDARY_COLLECTION_KEY = "chapter"
+
 class MarkdownProjectReader(private val isHelp: Boolean) : IProjectReader {
     private val collectionForEachFile = !isHelp
 
     private data class Contents(val collection: Collection, val list: List<Content>?)
+
+    private data class ProjectFileTree(
+        val tree: OtterTree<OtterFile>,
+        val projectRoot: OtterFile,
+        private val onClose: () -> Unit = {}
+    ) : Closeable {
+        override fun close() = onClose()
+    }
 
     /** @throws ImportException */
     override fun constructProjectTree(
@@ -31,74 +42,81 @@ class MarkdownProjectReader(private val isHelp: Boolean) : IProjectReader {
         project: Project,
         zipEntryTreeBuilder: IZipEntryTreeBuilder
     ): OtterTree<CollectionOrContent> {
-        val toClose = mutableListOf<Closeable>()
-        try {
-            val projectRoot: OtterFile
-            val projectTreeRoot: OtterTree<OtterFile>
-
-            when (container.file.extension) {
-                "zip" -> {
-                    val projectPathPrefixes = listOfNotNull(container.accessor.root, project.path)
-                    projectRoot = projectPathPrefixes
-                        .fold(container.file.toPath(), Path::resolve)
-                        .normalize()
-                        .toFile()
-                        .let(::otterFileF)
-                    val zip = ZipFile(container.file)
-                    // The ZipEntry tree needs the ZipFile to stay open until later, so remember to close it.
-                    toClose.add(zip)
-                    projectTreeRoot = zipEntryTreeBuilder.buildOtterFileTree(zip, project.path, container.accessor.root)
-                }
-                else -> {
-                    projectRoot = otterFileF(container.file.resolve(project.path))
-                    projectTreeRoot = container.file.resolve(project.path).buildFileTree()
-                }
+        return buildProjectFileTree(container, project, zipEntryTreeBuilder)
+            .use { (tree, projectRoot) ->
+                tree
+                    .filterMarkdownFiles()
+                    .map { f ->
+                        Contents(
+                            collection(file = f, projectRoot = projectRoot),
+                            if (f.isFile) f.readContents() else null
+                        )
+                    }
+                    .apply {
+                        // Set project info on the root node
+                        value.collection.labelKey = PRIMARY_COLLECTION_KEY
+                        value.collection.titleKey = project.title
+                    }
+                    .flattenContent()
             }
+    }
 
-            val collectionKey = container.manifest.dublinCore.identifier
+    private fun buildProjectFileTree(
+        container: ResourceContainer,
+        project: Project,
+        zipEntryTreeBuilder: IZipEntryTreeBuilder
+    ) = if (container.file.extension == "zip") {
+        val projectPathPrefixes = listOfNotNull(container.accessor.root, project.path)
+        val projectRoot = projectPathPrefixes
+            .fold(container.file.toPath(), Path::resolve)
+            .normalize()
+            .toFile()
+            .let(::otterFileF)
 
-            return projectTreeRoot
-                .filterMarkdownFiles()
-                ?.map { f ->
-                    Contents(
-                        collection(collectionKey, f, projectRoot),
-                        if (f.isFile) f.readContents() else null
-                    )
-                }
-                ?.flattenContent()
-                ?: throw ImportException(ImportResult.LOAD_RC_ERROR)
-        } finally {
-            toClose.forEach { it.close() }
-        }
+        val zip = ZipFile(container.file)
+        val tree = zipEntryTreeBuilder.buildOtterFileTree(zip, project.path, container.accessor.root)
+        ProjectFileTree(tree, projectRoot, zip::close)
+    } else {
+        val file = container.file.resolve(project.path)
+        ProjectFileTree(file.buildFileTree(), otterFileF(file))
     }
 
     private fun fileToId(f: OtterFile): Int =
         f.nameWithoutExtension.toIntOrNull() ?: 0
 
-    private fun fileToSlug(f: OtterFile, root: OtterFile): String =
-        root.parentFile?.let { parentFile ->
-            f.toRelativeString(parentFile)
-                .substringBeforeLast('.')
-                .split('/', '\\')
-                .map { it.toIntOrNull()?.toString() ?: it }
-                .joinToString("_")
-        }
-            ?: throw Exception("fileToSlug() call should not be made with null parentFile") // TODO. Also we could move this exception somewhere else if we set parentFile to a val
+    private fun fileToSlug(file: OtterFile, projectRoot: OtterFile): String =
+        file.toRelativeString(projectRoot)
+            .substringBeforeLast('.')
+            .split('/', '\\')
+            .joinToString("_", transform = this::simplifyTitle)
 
-    private fun collection(key: String, f: OtterFile, projectRoot: OtterFile): Collection {
-        val id = fileToId(f)
-        return Collection(
-            sort = id,
-            slug = fileToSlug(f, projectRoot),
-            labelKey = key,
-            titleKey = "$id",
-            resourceContainer = null
-        )
+    private fun fileToSort(file: OtterFile) = when (file.nameWithoutExtension) {
+        "back" -> 9999
+        else -> fileToId(file)
     }
+
+    private fun simplifyTitle(s: String) = s.toIntOrNull()?.toString() ?: s
+
+    private fun collection(file: OtterFile, projectRoot: OtterFile) = Collection(
+        sort = fileToSort(file),
+        slug = fileToSlug(file = file, projectRoot = projectRoot),
+        labelKey = SECONDARY_COLLECTION_KEY,
+        titleKey = simplifyTitle(file.nameWithoutExtension),
+        resourceContainer = null
+    )
 
     private fun content(sort: Int, id: Int, text: String, type: ContentType): Content? =
         if (text.isEmpty()) null
-        else Content(sort, ContentLabel.of(type).value, id, id, null, text, MimeType.MARKDOWN.norm, type)
+        else Content(
+            sort = sort,
+            labelKey = ContentLabel.of(type).value,
+            start = id,
+            end = id,
+            selectedTake = null,
+            text = text,
+            format = MimeType.MARKDOWN.norm,
+            type = type
+        )
 
     /**
      * Read an MD file and return its contents
@@ -123,8 +141,9 @@ class MarkdownProjectReader(private val isHelp: Boolean) : IProjectReader {
         }
     }
 
-    private fun OtterTree<OtterFile>.filterMarkdownFiles(): OtterTree<OtterFile>? =
+    private fun OtterTree<OtterFile>.filterMarkdownFiles(): OtterTree<OtterFile> =
         this.filterPreserveParents { it.isFile && extensions.matches(it.name) }
+            ?: throw ImportException(ImportResult.LOAD_RC_ERROR) // No markdown found
 
     /** Expand any list values to be individual tree nodes. */
     private fun OtterTree<Contents>.flattenContent(): OtterTree<CollectionOrContent> =


### PR DESCRIPTION
- Mark the top level collections as projects, so the wizard recognizes them.  
- Minor refactoring
- Tweak title and slug strings.

For https://github.com/WycliffeAssociates/otter-jvm/issues/460