### PR TITLE
Remove compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@ buildscript {
     ext.rxkotlin_version = '2.2.0'
     ext.ktlint_plugin_version = '8.2.0'
 
-
     repositories {
         mavenCentral()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
+    
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_plugin_version"
@@ -36,22 +36,24 @@ dependencies {
     compile "io.reactivex.rxjava2:rxkotlin:$rxkotlin_version"
     compile "com.jakewharton.rxrelay2:rxrelay:2.1.0"
 
-    //Testing
+    // Testing
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.mockito:mockito-core:2.+"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
 
-    //resource container
+    // Resource Container
     implementation 'org.wycliffeassociates:kotlin-resource-container'
 
-    //Jackson YAML
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.2"
+    // Explicitly mention reflection lib so Gradle and kotlin-resource-container's Jackson
+    // dependencies coexist w/o warnings. This can be removed once the krc lib is updated
+    // to Jackson 2.9.8+.
+    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
+
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/plugins/CreatePlugin.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/plugins/CreatePlugin.kt
@@ -11,6 +11,8 @@ class CreatePlugin(
         return pluginRepository
             .insert(data)
             .ignoreElement()
-            .concatWith(pluginRepository.initSelected())
+            .andThen {
+                pluginRepository.initSelected()
+            }
     }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/ParseUsfm.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/ParseUsfm.kt
@@ -42,7 +42,7 @@ class ParseUsfm(val reader: Reader) {
             MARKER_BOOK_NAME -> return
             MARKER_CHAPTER_NUMBER -> {
                 current.c = split[1]
-                    ?.replace("\\s".toRegex(), "")
+                    .replace("\\s".toRegex(), "")
                     .toInt() // strip potential whitespace and convert to int
                 chapters[current.c] = hashMapOf()
             }

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/domain/ImportResourceContainerTest.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/domain/ImportResourceContainerTest.kt
@@ -140,7 +140,7 @@ class MockCollectionRepository : ICollectionRepository {
         return Completable.complete()
     }
 
-    override fun insert(obj: Collection): Single<Int> {
+    override fun insert(collection: Collection): Single<Int> {
         return Single.just(1)
     }
 }
@@ -174,7 +174,7 @@ class MockLanguageRepository : ILanguageRepository {
         return Completable.complete()
     }
 
-    override fun insert(obj: Language): Single<Int> {
+    override fun insert(language: Language): Single<Int> {
         return Single.just(1)
     }
 }
@@ -213,7 +213,7 @@ class MockResourceMetadataRepository : IResourceMetadataRepository {
         return Completable.complete()
     }
 
-    override fun insert(obj: ResourceMetadata): Single<Int> {
+    override fun insert(metadata: ResourceMetadata): Single<Int> {
         return Single.just(1)
     }
 }

--- a/src/test/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/TestWorkbookRepository.kt
+++ b/src/test/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/TestWorkbookRepository.kt
@@ -323,7 +323,7 @@ class TestWorkbookRepository {
     fun chunksAreLazyLoad() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
 
         // Load some things that shouldn't trigger chunk fetch, and verify no DB call is made
         Assert.assertEquals(1, chapter.sort)
@@ -339,7 +339,7 @@ class TestWorkbookRepository {
     fun chunksAreCached() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
 
         // Fetch chunks twice, and verify only one DB call is made
         chapter.chunks.blockingLast()
@@ -350,7 +350,7 @@ class TestWorkbookRepository {
     @Test
     fun chunksIsAliasOfChapterChildren() {
         val workbook = buildBasicTestWorkbook()
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
 
         Assert.assertArrayEquals(
             chapter.children.blockingIterable().sortedBy { it.sort }.toTypedArray(),
@@ -361,7 +361,7 @@ class TestWorkbookRepository {
     @Test
     fun subtreeResourcesWork() {
         val workbook = buildBasicTestWorkbook()
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
 
         Assert.assertArrayEquals(arrayOf(resourceInfoTn), chapter.subtreeResources.toTypedArray())
     }
@@ -369,7 +369,7 @@ class TestWorkbookRepository {
     @Test
     fun resourceGroupsHaveCorrectInfo() {
         val workbook = buildBasicTestWorkbook()
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
         val resourceGroups = chunk.resources
 
@@ -382,7 +382,7 @@ class TestWorkbookRepository {
     fun resourcesAreLazyLoad() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
         val resourceGroup = chunk.resources.first()
 
@@ -398,7 +398,7 @@ class TestWorkbookRepository {
     @Test
     fun resourceGroupsHaveCorrectResources() {
         val workbook = buildBasicTestWorkbook()
-        val chapter = workbook.source.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.source.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "2" }.blockingSingle()
         val resourceGroup = chunk.resources.firstOrNull()
         Assert.assertNotNull(resourceGroup)
@@ -413,7 +413,7 @@ class TestWorkbookRepository {
     fun pushingToTakesRelayCallsDbWrite() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.target.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.blockingFirst()
         val takes = chunk.audio.takes
 
@@ -436,7 +436,7 @@ class TestWorkbookRepository {
     fun deletingTakeCallsDbWrite() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.target.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
         val takes = chunk.audio.takes
         val take = takes.blockingFirst()
@@ -453,7 +453,7 @@ class TestWorkbookRepository {
     fun settingSelectedTakeCallsDbWrite() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.target.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
         val takes = chunk.audio.takes
         val take = takes.blockingFirst()
@@ -470,7 +470,7 @@ class TestWorkbookRepository {
     fun deletingSelectedTakeResetsSelection() {
         val mockedDb = buildBasicTestDb()
         val workbook = buildBasicTestWorkbook(mockedDb)
-        val chapter = workbook.target.chapters.blockingIterable().sortedBy { it.sort }.first()
+        val chapter = workbook.target.chapters.blockingIterable().minBy { it.sort }!!
         val chunk = chapter.chunks.filter { it.title == "3" }.blockingSingle()
         val takes = chunk.audio.takes
         val take = takes.blockingFirst()
@@ -502,8 +502,7 @@ class TestWorkbookRepository {
         chunks.forEach {
             Assert.assertTrue(
                 "Chunk text expected",
-                it.textItem?.text?.startsWith("/v ${it.title}")
-                    ?: false
+                it.textItem.text.startsWith("/v ${it.title}")
             )
         }
     }


### PR DESCRIPTION
Fix Kotlin compiler warnings:

- Unnecessary null-safe `?.` calls
- Always-true or -false conditional predicates
- Java enum interop warnings (can be nullable)
- Unused parameters
- Variable name shadowing
- Deprecated API use
- Ambiguous `return@` targets
- Overridden methods with differently named parameters
- Specify version of sub-dependency explicitly when dependencies have conflict
- More?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-common/110)
<!-- Reviewable:end -->
