### PR TITLE
Treat compiler warnings as errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,10 @@ dependencies {
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.allWarningsAsErrors = true
 }
+
 compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.allWarningsAsErrors = true
 }


### PR DESCRIPTION
If #110 is merged, this will block new warnings from being committed.

This will, of course fail the build verification tests in Travis. PR #123 simply merges this and #110, so you can see their combined effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-common/111)
<!-- Reviewable:end -->
