### PR TITLE
Update EditTake.kt

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/EditTake.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/EditTake.kt
@@ -1,28 +1,26 @@
 package org.wycliffeassociates.otter.common.domain.content
 
 import io.reactivex.Single
-import org.wycliffeassociates.otter.common.data.model.Take
+import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.domain.plugins.LaunchPlugin
-import org.wycliffeassociates.otter.common.persistence.repositories.ITakeRepository
 import java.time.LocalDate
 
 class EditTake(
-        private val takeRepository: ITakeRepository,
         private val launchPlugin: LaunchPlugin
 ) {
     enum class Result {
         SUCCESS,
         NO_EDITOR
     }
-    fun edit(take: Take): Single<Result> {
-        take.created = LocalDate.now()
-        return launchPlugin
-                .launchEditor(take.path)
-                .flatMap {
-                    when (it) {
-                        LaunchPlugin.Result.SUCCESS -> takeRepository.update(take).toSingle { Result.SUCCESS }
-                        LaunchPlugin.Result.NO_PLUGIN -> Single.just(Result.NO_EDITOR)
-                    }
+    fun edit(take: Take): Single<Result> = launchPlugin
+        .launchEditor(take.file)
+        .map {
+            when (it) {
+                LaunchPlugin.Result.SUCCESS -> {
+                    // TODO
+                    Result.SUCCESS
                 }
-    }
+                LaunchPlugin.Result.NO_PLUGIN -> Result.NO_EDITOR
+            }
+        }
 }

--- a/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/EditTake.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/EditTake.kt
@@ -16,10 +16,7 @@ class EditTake(
         .launchEditor(take.file)
         .map {
             when (it) {
-                LaunchPlugin.Result.SUCCESS -> {
-                    // TODO
-                    Result.SUCCESS
-                }
+                LaunchPlugin.Result.SUCCESS -> Result.SUCCESS
                 LaunchPlugin.Result.NO_PLUGIN -> Result.NO_EDITOR
             }
         }


### PR DESCRIPTION
EditTake won't use TakeRepository anymore to edit the take. We simply need to reload the file when it gets edited, and we can use file.lastModified() if we need to find out when it was last changed.

Note: editing takes is still broken until we figure out what is why ocenaudio cannot save a file when ocenaudio is opened from the app.

Supports [jvm #468](https://github.com/WycliffeAssociates/otter-jvm/pull/468)