### PR TITLE
Fix crash on navigate back when stack is empty

### DIFF
--- a/src/main/kotlin/org/wycliffeassociates/otter/common/navigation/INavigator.kt
+++ b/src/main/kotlin/org/wycliffeassociates/otter/common/navigation/INavigator.kt
@@ -9,10 +9,12 @@ interface INavigator {
     val tabGroupBuilder: ITabGroupBuilder
 
     fun back() {
-        currentGroup?.deactivate()
-        val previousGroup = navBackStack.pop()
-        previousGroup.activate()
-        currentGroup = previousGroup
+        if (navBackStack.isNotEmpty()) {
+            currentGroup?.deactivate()
+            val previousGroup = navBackStack.pop()
+            previousGroup.activate()
+            currentGroup = previousGroup
+        }
     }
 
     fun navigateTo(tabGroupType: TabGroupType) {


### PR DESCRIPTION
Fixes a bug where the app could crash if the user clicks on the back button when the navigation back stack is empty. This PR is in addition to jvm [#499](https://github.com/WycliffeAssociates/otter-jvm/pull/499) which disables the back button altogether when the back stack is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/otter-common/131)
<!-- Reviewable:end -->
